### PR TITLE
corrected link to README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ See also the list of [contributors](https://github.com/your/project/contributors
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details.
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
 <!-- ## Acknowledgments
 


### PR DESCRIPTION
the link was to a md file, while in reality the README file is without extension  